### PR TITLE
fix warning in NavMain.js (React inline styles, need camelCase for st…

### DIFF
--- a/src/components/shared/Nav/NavMain/NavMain.js
+++ b/src/components/shared/Nav/NavMain/NavMain.js
@@ -44,7 +44,7 @@ const NavMain = () => {
           <Link to='/'>
             <FontAwesomeIcon
               icon={faLocationDot}
-              style={{ color: 'white', 'margin-right': '10px' }}
+              style={{ color: 'white', marginRight: '10px' }}
               className='title-icon'
             />
             PlaceBook


### PR DESCRIPTION
…yle property names, not kebab-case like in CSS)